### PR TITLE
fix: image expanding beyond application window size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.idea/
 bin/
 bin/*
 obj/

--- a/ImageAnnotator/MainWindow.xaml
+++ b/ImageAnnotator/MainWindow.xaml
@@ -119,7 +119,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="100"></ColumnDefinition>
                 <ColumnDefinition Width="5"></ColumnDefinition>
-                <ColumnDefinition Width="Auto"></ColumnDefinition>
+                <ColumnDefinition Width="*"></ColumnDefinition>
             </Grid.ColumnDefinitions>
 
             <StackPanel Grid.Column="0" Orientation="Vertical">
@@ -142,7 +142,8 @@
             <GridSplitter Grid.Column="1"  HorizontalAlignment="Stretch" />
 
             <!-- We want to be able to zoom in -->
-            <ScrollViewer Grid.Column="2" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
+            <!-- <ScrollViewer Grid.Column="2" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"> -->
+            <Border Grid.Column="2" ClipToBounds="True" Background="Transparent">
                 <!--
                     Elements in a grid canvas are overlayed on top each other that is
                     why we specify grid here
@@ -176,7 +177,7 @@
                         </Canvas.Style>
                     </Canvas>
                 </Grid>
-            </ScrollViewer>
+            </Border>
         </Grid>
 
         <TextBox Name="CodeText" Grid.Row="2" FontSize="12" IsReadOnly="True"/>


### PR DESCRIPTION
Replaced the `ScrollViewer` with a `Border (ClipToBounds="True")` and updated the image container's `Grid.ColumnDefinition Width` from `Auto` to `*` (star sizing). This properly constrains the layout bounds, allowing large images to automatically shrink and fit within the application's viewable area instead of expanding infinitely.